### PR TITLE
0x100になったときもZF=1

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -281,7 +281,7 @@ const add_or_sub = (operator) => {
     }
 
     // 計算結果が0ならzeroフラグを立てる
-    if (result === 0) {
+    if ((result & 0xff) === 0) {
         flags[1] = true;
     } else {
         flags[1] = false;


### PR DESCRIPTION
例えば A=0x64, B=0x9c のときに add a, a, b を実行したときもZF=1にすべき（Aには0が代入されるから）